### PR TITLE
Add week and quarter views to timeline filter

### DIFF
--- a/src/components/GanttChart.tsx
+++ b/src/components/GanttChart.tsx
@@ -1,27 +1,18 @@
-import React, { useEffect, useRef, useState } from "react";
-import {
-  Card,
-  Typography,
-  Space,
-  Button,
-  Select,
-  DatePicker,
-  Row,
-  Col,
-} from "antd";
-import {
-  CalendarOutlined,
-  ProjectOutlined,
+import React, { useEffect, useRef, useState } from 'react';
+import { Card, Typography, Space, Button, Select, DatePicker, Row, Col } from 'antd';
+import { 
+  CalendarOutlined, 
+  ProjectOutlined, 
   FullscreenOutlined,
   ZoomInOutlined,
   ZoomOutOutlined,
   LinkOutlined,
-  ExclamationCircleOutlined,
-} from "@ant-design/icons";
-import { useData } from "../contexts/DataContext";
-import { useAuth } from "../contexts/AuthContext";
-import dayjs from "dayjs";
-import minMax from "dayjs/plugin/minMax";
+  ExclamationCircleOutlined
+} from '@ant-design/icons';
+import { useData } from '../contexts/DataContext';
+import { useAuth } from '../contexts/AuthContext';
+import dayjs from 'dayjs';
+import minMax from 'dayjs/plugin/minMax';
 
 dayjs.extend(minMax);
 
@@ -35,39 +26,31 @@ const GanttChart: React.FC = () => {
   const ganttRef = useRef<HTMLDivElement>(null);
 
   // Filter states
-  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(
-    null
-  );
+  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(null);
   const [selectedStatus, setSelectedStatus] = useState<string | null>(null);
-  const [dateRange, setDateRange] = useState<
-    [dayjs.Dayjs | null, dayjs.Dayjs | null] | null
-  >(null);
-  const [timelineView, setTimelineView] = useState<
-    "week" | "month" | "quarter"
-  >("month");
+  const [dateRange, setDateRange] = useState<[dayjs.Dayjs | null, dayjs.Dayjs | null] | null>(null);
+  const [timelineView, setTimelineView] = useState<'week' | 'month' | 'quarter'>('month');
 
   // Filter data based on user role
-  let userProjects =
-    user?.role === "admin"
-      ? projects
-      : projects.filter((p) => user?.projectIds?.includes(p.id));
+  let userProjects = user?.role === 'admin'
+    ? projects
+    : projects.filter(p => user?.projectIds?.includes(p.id));
 
-  let userTasks =
-    user?.role === "executive"
-      ? tasks.filter((t) => t.assignedTo === user.id)
-      : tasks.filter((t) => userProjects.some((p) => p.id === t.projectId));
+  let userTasks = user?.role === 'executive'
+    ? tasks.filter(t => t.assignedTo === user.id)
+    : tasks.filter(t => userProjects.some(p => p.id === t.projectId));
 
   // Apply timeline filters
   // 1. Project filter - when selected, show only that project
   if (selectedProjectId) {
-    userProjects = userProjects.filter((p) => p.id === selectedProjectId);
-    userTasks = userTasks.filter((t) => t.projectId === selectedProjectId);
+    userProjects = userProjects.filter(p => p.id === selectedProjectId);
+    userTasks = userTasks.filter(t => t.projectId === selectedProjectId);
   }
 
   // 2. Status filter - apply to both projects and tasks
   if (selectedStatus) {
-    userProjects = userProjects.filter((p) => p.status === selectedStatus);
-    userTasks = userTasks.filter((t) => t.status === selectedStatus);
+    userProjects = userProjects.filter(p => p.status === selectedStatus);
+    userTasks = userTasks.filter(t => t.status === selectedStatus);
   }
 
   // 3. Date range filter - show items that overlap with selected date range
@@ -75,24 +58,18 @@ const GanttChart: React.FC = () => {
     const startDate = dateRange[0];
     const endDate = dateRange[1];
 
-    userProjects = userProjects.filter((p) => {
+    userProjects = userProjects.filter(p => {
       const projectStart = dayjs(p.startDate);
       const projectEnd = dayjs(p.endDate);
       // Check if project dates overlap with filter range
-      return (
-        projectStart.isBefore(endDate.add(1, "day")) &&
-        projectEnd.isAfter(startDate.subtract(1, "day"))
-      );
+      return projectStart.isBefore(endDate.add(1, 'day')) && projectEnd.isAfter(startDate.subtract(1, 'day'));
     });
 
-    userTasks = userTasks.filter((t) => {
+    userTasks = userTasks.filter(t => {
       const taskStart = dayjs(t.createdDate);
       const taskEnd = dayjs(t.dueDate);
       // Check if task dates overlap with filter range
-      return (
-        taskStart.isBefore(endDate.add(1, "day")) &&
-        taskEnd.isAfter(startDate.subtract(1, "day"))
-      );
+      return taskStart.isBefore(endDate.add(1, 'day')) && taskEnd.isAfter(startDate.subtract(1, 'day'));
     });
   }
 
@@ -102,29 +79,29 @@ const GanttChart: React.FC = () => {
   // Generate timeline data
   const generateTimelineData = () => {
     const allItems = [
-      ...userProjects.map((project) => ({
+      ...userProjects.map(project => ({
         id: `project-${project.id}`,
         name: project.name,
-        type: "project",
+        type: 'project',
         start: dayjs(project.startDate),
         end: dayjs(project.endDate),
         progress: project.progress,
         status: project.status,
         parent: null,
-        level: 0,
+        level: 0
       })),
-      ...userTasks.map((task) => ({
+      ...userTasks.map(task => ({
         id: `task-${task.id}`,
         name: task.title,
-        type: "task",
+        type: 'task',
         start: dayjs(task.createdDate),
         end: dayjs(task.dueDate),
         progress: task.progress,
         status: task.status,
         parent: `project-${task.projectId}`,
         level: 1,
-        priority: task.priority,
-      })),
+        priority: task.priority
+      }))
     ];
 
     return allItems.sort((a, b) => {
@@ -137,27 +114,26 @@ const GanttChart: React.FC = () => {
 
   // Calculate timeline bounds
   const getTimelineBounds = () => {
-    if (timelineData.length === 0)
-      return { start: dayjs(), end: dayjs().add(1, "month") };
-
-    const starts = timelineData.map((item) => item.start);
-    const ends = timelineData.map((item) => item.end);
-
-    const minStart = dayjs.min(starts)?.subtract(1, "week") || dayjs();
-    const maxEnd = dayjs.max(ends)?.add(1, "week") || dayjs().add(1, "month");
-
+    if (timelineData.length === 0) return { start: dayjs(), end: dayjs().add(1, 'month') };
+    
+    const starts = timelineData.map(item => item.start);
+    const ends = timelineData.map(item => item.end);
+    
+    const minStart = dayjs.min(starts)?.subtract(1, 'week') || dayjs();
+    const maxEnd = dayjs.max(ends)?.add(1, 'week') || dayjs().add(1, 'month');
+    
     return { start: minStart, end: maxEnd };
   };
 
   const { start: timelineStart, end: timelineEnd } = getTimelineBounds();
-  const totalDays = timelineEnd.diff(timelineStart, "days");
+  const totalDays = timelineEnd.diff(timelineStart, 'days');
 
   // Generate timeline headers based on view type
   const generateTimelineHeaders = () => {
     switch (timelineView) {
-      case "week":
+      case 'week':
         return generateWeekHeaders();
-      case "quarter":
+      case 'quarter':
         return generateQuarterHeaders();
       default:
         return generateMonthHeaders();
@@ -167,21 +143,22 @@ const GanttChart: React.FC = () => {
   // Generate week headers
   const generateWeekHeaders = () => {
     const weeks = [];
-    let current = timelineStart.startOf("week");
+    let current = timelineStart.startOf('week');
 
     while (current.isBefore(timelineEnd)) {
-      const weekEnd = current.endOf("week");
-      const daysInWeek = Math.min(7, timelineEnd.diff(current, "days") + 1);
+      const weekEnd = current.endOf('week');
+      const daysInWeek = Math.min(
+        7,
+        timelineEnd.diff(current, 'days') + 1
+      );
 
       weeks.push({
-        label: `Week ${current.week()} (${current.format(
-          "MMM DD"
-        )} - ${weekEnd.format("MMM DD")})`,
+        label: `Week ${current.week()} (${current.format('MMM DD')} - ${weekEnd.format('MMM DD')})`,
         days: daysInWeek,
-        width: (daysInWeek / totalDays) * 100,
+        width: (daysInWeek / totalDays) * 100
       });
 
-      current = current.add(1, "week");
+      current = current.add(1, 'week');
     }
 
     return weeks;
@@ -190,21 +167,21 @@ const GanttChart: React.FC = () => {
   // Generate month headers
   const generateMonthHeaders = () => {
     const months = [];
-    let current = timelineStart.startOf("month");
+    let current = timelineStart.startOf('month');
 
     while (current.isBefore(timelineEnd)) {
       const daysInMonth = Math.min(
         current.daysInMonth(),
-        timelineEnd.diff(current, "days") + 1
+        timelineEnd.diff(current, 'days') + 1
       );
 
       months.push({
-        label: current.format("MMM YYYY"),
+        label: current.format('MMM YYYY'),
         days: daysInMonth,
-        width: (daysInMonth / totalDays) * 100,
+        width: (daysInMonth / totalDays) * 100
       });
 
-      current = current.add(1, "month");
+      current = current.add(1, 'month');
     }
 
     return months;
@@ -213,24 +190,22 @@ const GanttChart: React.FC = () => {
   // Generate quarter headers
   const generateQuarterHeaders = () => {
     const quarters = [];
-    let current = timelineStart.startOf("quarter");
+    let current = timelineStart.startOf('quarter');
 
     while (current.isBefore(timelineEnd)) {
-      const quarterEnd = current.endOf("quarter");
+      const quarterEnd = current.endOf('quarter');
       const daysInQuarter = Math.min(
-        quarterEnd.diff(current, "days") + 1,
-        timelineEnd.diff(current, "days") + 1
+        quarterEnd.diff(current, 'days') + 1,
+        timelineEnd.diff(current, 'days') + 1
       );
 
       quarters.push({
-        label: `Q${current.quarter()} ${current.format(
-          "YYYY"
-        )} (${current.format("MMM")} - ${quarterEnd.format("MMM")})`,
+        label: `Q${current.quarter()} ${current.format('YYYY')} (${current.format('MMM')} - ${quarterEnd.format('MMM')})`,
         days: daysInQuarter,
-        width: (daysInQuarter / totalDays) * 100,
+        width: (daysInQuarter / totalDays) * 100
       });
 
-      current = current.add(1, "quarter");
+      current = current.add(1, 'quarter');
     }
 
     return quarters;
@@ -240,51 +215,49 @@ const GanttChart: React.FC = () => {
 
   // Calculate bar position and width
   const calculateBarStyle = (item: any) => {
-    const startOffset = item.start.diff(timelineStart, "days");
-    const duration = item.end.diff(item.start, "days") + 1;
-
+    const startOffset = item.start.diff(timelineStart, 'days');
+    const duration = item.end.diff(item.start, 'days') + 1;
+    
     const left = (startOffset / totalDays) * 100;
     const width = (duration / totalDays) * 100;
-
+    
     return { left: `${left}%`, width: `${width}%` };
   };
 
   // Get status color
   const getStatusColor = (status: string, type: string) => {
-    if (type === "project") {
+    if (type === 'project') {
       const colors = {
-        planning: "#faad14",
-        "in-progress": "#1890ff",
-        completed: "#52c41a",
-        "on-hold": "#f5222d",
+        'planning': '#faad14',
+        'in-progress': '#1890ff',
+        'completed': '#52c41a',
+        'on-hold': '#f5222d'
       };
-      return colors[status as keyof typeof colors] || "#d9d9d9";
+      return colors[status as keyof typeof colors] || '#d9d9d9';
     } else {
       const colors = {
-        "not-started": "#d9d9d9",
-        "in-progress": "#1890ff",
-        completed: "#52c41a",
-        "on-hold": "#faad14",
+        'not-started': '#d9d9d9',
+        'in-progress': '#1890ff',
+        'completed': '#52c41a',
+        'on-hold': '#faad14'
       };
-      return colors[status as keyof typeof colors] || "#d9d9d9";
+      return colors[status as keyof typeof colors] || '#d9d9d9';
     }
   };
 
   const getPriorityColor = (priority?: string) => {
-    const colors = { high: "#f5222d", medium: "#faad14", low: "#52c41a" };
-    return colors[priority as keyof typeof colors] || "#1890ff";
+    const colors = { high: '#f5222d', medium: '#faad14', low: '#52c41a' };
+    return colors[priority as keyof typeof colors] || '#1890ff';
   };
 
   return (
     <div>
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-          marginBottom: 24,
-        }}
-      >
+      <div style={{ 
+        display: 'flex', 
+        justifyContent: 'space-between', 
+        alignItems: 'center',
+        marginBottom: 24
+      }}>
         <Title level={2} style={{ margin: 0 }}>
           <CalendarOutlined /> Project Timeline (Gantt Chart)
         </Title>
@@ -307,71 +280,39 @@ const GanttChart: React.FC = () => {
       <Card>
         <div style={{ marginBottom: 16 }}>
           {/* Filter Status */}
-          <div
-            style={{
-              marginBottom: 12,
-              padding: "8px 12px",
-              backgroundColor:
-                selectedProjectId || selectedStatus || dateRange
-                  ? "#f6ffed"
-                  : "#f5f5f5",
-              border:
-                selectedProjectId || selectedStatus || dateRange
-                  ? "1px solid #b7eb8f"
-                  : "1px solid #d9d9d9",
-              borderRadius: "4px",
-              fontSize: "12px",
-            }}
-          >
+          <div style={{
+            marginBottom: 12,
+            padding: '8px 12px',
+            backgroundColor: (selectedProjectId || selectedStatus || dateRange) ? '#f6ffed' : '#f5f5f5',
+            border: (selectedProjectId || selectedStatus || dateRange) ? '1px solid #b7eb8f' : '1px solid #d9d9d9',
+            borderRadius: '4px',
+            fontSize: '12px'
+          }}>
             <Space>
-              {selectedProjectId || selectedStatus || dateRange ? (
+              {(selectedProjectId || selectedStatus || dateRange) ? (
                 <>
                   <span>Active Filters:</span>
                   {selectedProjectId && (
-                    <span
-                      style={{
-                        background: "#52c41a",
-                        color: "#fff",
-                        padding: "2px 6px",
-                        borderRadius: "2px",
-                      }}
-                    >
-                      Project:{" "}
-                      {projects.find((p) => p.id === selectedProjectId)?.name}
+                    <span style={{ background: '#52c41a', color: '#fff', padding: '2px 6px', borderRadius: '2px' }}>
+                      Project: {projects.find(p => p.id === selectedProjectId)?.name}
                     </span>
                   )}
                   {selectedStatus && (
-                    <span
-                      style={{
-                        background: "#1890ff",
-                        color: "#fff",
-                        padding: "2px 6px",
-                        borderRadius: "2px",
-                      }}
-                    >
+                    <span style={{ background: '#1890ff', color: '#fff', padding: '2px 6px', borderRadius: '2px' }}>
                       Status: {selectedStatus}
                     </span>
                   )}
                   {dateRange && dateRange[0] && dateRange[1] && (
-                    <span
-                      style={{
-                        background: "#722ed1",
-                        color: "#fff",
-                        padding: "2px 6px",
-                        borderRadius: "2px",
-                      }}
-                    >
-                      Date: {dateRange[0].format("MMM DD")} -{" "}
-                      {dateRange[1].format("MMM DD")}
+                    <span style={{ background: '#722ed1', color: '#fff', padding: '2px 6px', borderRadius: '2px' }}>
+                      Date: {dateRange[0].format('MMM DD')} - {dateRange[1].format('MMM DD')}
                     </span>
                   )}
                 </>
               ) : (
                 <span>No filters applied - showing all data</span>
               )}
-              <span style={{ color: "#666" }}>
-                | Showing: {userProjects.length} projects, {userTasks.length}{" "}
-                tasks
+              <span style={{ color: '#666' }}>
+                | Showing: {userProjects.length} projects, {userTasks.length} tasks
               </span>
             </Space>
           </div>
@@ -380,27 +321,22 @@ const GanttChart: React.FC = () => {
             <Col xs={24} sm={6}>
               <Select
                 placeholder="Filter by Project (All by default)"
-                style={{ width: "100%" }}
+                style={{ width: '100%' }}
                 allowClear
                 value={selectedProjectId}
                 onChange={(value) => setSelectedProjectId(value)}
               >
-                {projects
-                  .filter(
-                    (p) =>
-                      user?.role === "admin" || user?.projectIds?.includes(p.id)
-                  )
-                  .map((project) => (
-                    <Option key={project.id} value={project.id}>
-                      {project.name}
-                    </Option>
-                  ))}
+                {projects.filter(p => user?.role === 'admin' || user?.projectIds?.includes(p.id)).map(project => (
+                  <Option key={project.id} value={project.id}>
+                    {project.name}
+                  </Option>
+                ))}
               </Select>
             </Col>
             <Col xs={24} sm={6}>
               <Select
                 placeholder="Filter by Status (All by default)"
-                style={{ width: "100%" }}
+                style={{ width: '100%' }}
                 allowClear
                 value={selectedStatus}
                 onChange={(value) => setSelectedStatus(value)}
@@ -414,8 +350,8 @@ const GanttChart: React.FC = () => {
             </Col>
             <Col xs={24} sm={6}>
               <DatePicker.RangePicker
-                style={{ width: "100%" }}
-                placeholder={["Start Date", "End Date"]}
+                style={{ width: '100%' }}
+                placeholder={['Start Date', 'End Date']}
                 value={dateRange}
                 onChange={(dates) => setDateRange(dates)}
               />
@@ -427,7 +363,7 @@ const GanttChart: React.FC = () => {
                   setSelectedStatus(null);
                   setDateRange(null);
                 }}
-                style={{ width: "100%" }}
+                style={{ width: '100%' }}
               >
                 Clear Filters
               </Button>
@@ -435,75 +371,64 @@ const GanttChart: React.FC = () => {
           </Row>
         </div>
 
-        <div
+        <div 
           ref={ganttRef}
-          style={{
-            border: "1px solid #f0f0f0",
-            borderRadius: "6px",
-            overflow: "auto",
-            minHeight: "500px",
-            backgroundColor: "#fafafa",
+          style={{ 
+            border: '1px solid #f0f0f0',
+            borderRadius: '6px',
+            overflow: 'auto',
+            minHeight: '500px',
+            backgroundColor: '#fafafa'
           }}
         >
           {/* Header */}
-          <div
-            style={{
-              display: "flex",
-              borderBottom: "2px solid #e8e8e8",
-              backgroundColor: "#fff",
-              position: "sticky",
-              top: 0,
-              zIndex: 10,
-            }}
-          >
+          <div style={{ 
+            display: 'flex',
+            borderBottom: '2px solid #e8e8e8',
+            backgroundColor: '#fff',
+            position: 'sticky',
+            top: 0,
+            zIndex: 10
+          }}>
             {/* Task Names Column */}
-            <div
-              style={{
-                width: "300px",
-                minWidth: "300px",
-                borderRight: "2px solid #e8e8e8",
-                backgroundColor: "#fafafa",
-              }}
-            >
-              <div
-                style={{
-                  padding: "12px 16px",
-                  fontWeight: "bold",
-                  borderBottom: "1px solid #e8e8e8",
-                  backgroundColor: "#f5f5f5",
-                }}
-              >
+            <div style={{ 
+              width: '300px',
+              minWidth: '300px',
+              borderRight: '2px solid #e8e8e8',
+              backgroundColor: '#fafafa'
+            }}>
+              <div style={{ 
+                padding: '12px 16px',
+                fontWeight: 'bold',
+                borderBottom: '1px solid #e8e8e8',
+                backgroundColor: '#f5f5f5'
+              }}>
                 Task / Project Name
               </div>
             </div>
 
             {/* Timeline Header */}
-            <div style={{ flex: 1, minWidth: "800px" }}>
+            <div style={{ flex: 1, minWidth: '800px' }}>
               {/* Timeline Headers */}
-              <div
-                style={{
-                  display: "flex",
-                  borderBottom: "1px solid #e8e8e8",
-                  backgroundColor: "#f5f5f5",
-                }}
-              >
+              <div style={{
+                display: 'flex',
+                borderBottom: '1px solid #e8e8e8',
+                backgroundColor: '#f5f5f5'
+              }}>
                 {timelineHeaders.map((header, index) => (
                   <div
                     key={index}
                     style={{
                       width: `${header.width}%`,
-                      padding: "8px 4px",
-                      textAlign: "center",
-                      fontSize: timelineView === "week" ? "10px" : "12px",
-                      fontWeight: "bold",
-                      borderRight:
-                        index < timelineHeaders.length - 1
-                          ? "1px solid #e8e8e8"
-                          : "none",
-                      minHeight: "32px",
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
+                      padding: '8px 4px',
+                      textAlign: 'center',
+                      fontSize: timelineView === 'week' ? '10px' : '12px',
+                      fontWeight: 'bold',
+                      borderRight: index < timelineHeaders.length - 1 ? '1px solid #e8e8e8' : 'none',
+                      minHeight: '32px',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center'
                     }}
                   >
                     {header.label}
@@ -512,25 +437,23 @@ const GanttChart: React.FC = () => {
               </div>
 
               {/* Sub-grid based on view type */}
-              {timelineView === "month" && (
-                <div
-                  style={{
-                    display: "flex",
-                    height: "30px",
-                    backgroundColor: "#f9f9f9",
-                  }}
-                >
+              {timelineView === 'month' && (
+                <div style={{
+                  display: 'flex',
+                  height: '30px',
+                  backgroundColor: '#f9f9f9'
+                }}>
                   {Array.from({ length: Math.ceil(totalDays / 7) }, (_, i) => (
                     <div
                       key={i}
                       style={{
                         width: `${(7 / totalDays) * 100}%`,
-                        borderRight: "1px solid #e8e8e8",
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        fontSize: "10px",
-                        color: "#666",
+                        borderRight: '1px solid #e8e8e8',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        fontSize: '10px',
+                        color: '#666'
                       }}
                     >
                       W{i + 1}
@@ -538,59 +461,55 @@ const GanttChart: React.FC = () => {
                   ))}
                 </div>
               )}
-              {/* {timelineView === "week" && (
-                <div
-                  style={{
-                    display: "flex",
-                    height: "30px",
-                    backgroundColor: "#f9f9f9",
-                  }}
-                >
+              {timelineView === 'week' && (
+                <div style={{
+                  display: 'flex',
+                  height: '30px',
+                  backgroundColor: '#f9f9f9'
+                }}>
                   {Array.from({ length: totalDays }, (_, i) => {
-                    const date = timelineStart.add(i, "day");
+                    const date = timelineStart.add(i, 'day');
                     return (
                       <div
                         key={i}
                         style={{
                           width: `${(1 / totalDays) * 100}%`,
-                          borderRight: "1px solid #e8e8e8",
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          fontSize: "9px",
-                          color: "#666",
+                          borderRight: '1px solid #e8e8e8',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          fontSize: '9px',
+                          color: '#666'
                         }}
                       >
-                        {date.format("DD")}
+                        {date.format('DD')}
                       </div>
                     );
                   })}
                 </div>
-              )} */}
-              {timelineView === "quarter" && (
-                <div
-                  style={{
-                    display: "flex",
-                    height: "30px",
-                    backgroundColor: "#f9f9f9",
-                  }}
-                >
+              )}
+              {timelineView === 'quarter' && (
+                <div style={{
+                  display: 'flex',
+                  height: '30px',
+                  backgroundColor: '#f9f9f9'
+                }}>
                   {Array.from({ length: Math.ceil(totalDays / 30) }, (_, i) => {
-                    const monthStart = timelineStart.add(i * 30, "day");
+                    const monthStart = timelineStart.add(i * 30, 'day');
                     return (
                       <div
                         key={i}
                         style={{
                           width: `${(30 / totalDays) * 100}%`,
-                          borderRight: "1px solid #e8e8e8",
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          fontSize: "10px",
-                          color: "#666",
+                          borderRight: '1px solid #e8e8e8',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          fontSize: '10px',
+                          color: '#666'
                         }}
                       >
-                        {monthStart.format("MMM")}
+                        {monthStart.format('MMM')}
                       </div>
                     );
                   })}
@@ -605,60 +524,45 @@ const GanttChart: React.FC = () => {
               <div
                 key={item.id}
                 style={{
-                  display: "flex",
-                  borderBottom: "1px solid #f0f0f0",
-                  minHeight: "50px",
-                  backgroundColor: index % 2 === 0 ? "#fff" : "#fafafa",
+                  display: 'flex',
+                  borderBottom: '1px solid #f0f0f0',
+                  minHeight: '50px',
+                  backgroundColor: index % 2 === 0 ? '#fff' : '#fafafa'
                 }}
               >
                 {/* Task Name */}
-                <div
-                  style={{
-                    width: "300px",
-                    minWidth: "300px",
-                    borderRight: "1px solid #f0f0f0",
-                    padding: "12px 16px",
-                    display: "flex",
-                    alignItems: "center",
-                  }}
-                >
-                  <div
-                    style={{
-                      marginLeft: item.level * 20,
-                      width: "100%",
-                    }}
-                  >
-                    <div
-                      style={{
-                        fontWeight: item.type === "project" ? "bold" : "normal",
-                        fontSize: item.type === "project" ? "14px" : "13px",
-                        color: item.type === "project" ? "#1890ff" : "#333",
-                        marginBottom: "2px",
-                      }}
-                    >
-                      {item.type === "project" && (
-                        <ProjectOutlined style={{ marginRight: 8 }} />
-                      )}
-                      {item.name.length > 35
-                        ? item.name.substring(0, 35) + "..."
-                        : item.name}
+                <div style={{ 
+                  width: '300px',
+                  minWidth: '300px',
+                  borderRight: '1px solid #f0f0f0',
+                  padding: '12px 16px',
+                  display: 'flex',
+                  alignItems: 'center'
+                }}>
+                  <div style={{ 
+                    marginLeft: item.level * 20,
+                    width: '100%'
+                  }}>
+                    <div style={{ 
+                      fontWeight: item.type === 'project' ? 'bold' : 'normal',
+                      fontSize: item.type === 'project' ? '14px' : '13px',
+                      color: item.type === 'project' ? '#1890ff' : '#333',
+                      marginBottom: '2px'
+                    }}>
+                      {item.type === 'project' && <ProjectOutlined style={{ marginRight: 8 }} />}
+                      {item.name.length > 35 ? item.name.substring(0, 35) + '...' : item.name}
                     </div>
-                    <div
-                      style={{
-                        fontSize: "11px",
-                        color: "#666",
-                      }}
-                    >
-                      {item.start.format("MMM DD")} -{" "}
-                      {item.end.format("MMM DD, YYYY")}
-                      {item.type === "task" && item.priority && (
-                        <span
-                          style={{
-                            marginLeft: 8,
-                            color: getPriorityColor(item.priority),
-                            fontWeight: "bold",
-                          }}
-                        >
+                    <div style={{ 
+                      fontSize: '11px',
+                      color: '#666'
+                    }}>
+                      {item.start.format('MMM DD')} - {item.end.format('MMM DD, YYYY')}
+                      {item.type === 'task' && item.priority && (
+                        <span style={{ 
+                          marginLeft: 8,
+                          color: getPriorityColor(item.priority),
+                          fontWeight: 'bold'
+                        }}>
                           {item.priority.toUpperCase()}
                         </span>
                       )}
@@ -667,153 +571,126 @@ const GanttChart: React.FC = () => {
                 </div>
 
                 {/* Timeline Bar */}
-                <div
-                  style={{
-                    flex: 1,
-                    minWidth: "800px",
-                    position: "relative",
-                    padding: "15px 0",
-                  }}
-                >
+                <div style={{ 
+                  flex: 1,
+                  minWidth: '800px',
+                  position: 'relative',
+                  padding: '15px 0'
+                }}>
                   {/* Background Grid */}
-                  <div
-                    style={{
-                      position: "absolute",
-                      top: 0,
-                      left: 0,
-                      right: 0,
-                      bottom: 0,
-                      display: "flex",
-                    }}
-                  >
-                    {timelineView === "week"
-                      ? Array.from({ length: totalDays }, (_, i) => (
-                          <div
-                            key={i}
-                            style={{
-                              width: `${(1 / totalDays) * 100}%`,
-                              borderRight: "1px solid #f0f0f0",
-                            }}
-                          />
-                        ))
-                      : timelineView === "quarter"
-                      ? Array.from(
-                          { length: Math.ceil(totalDays / 30) },
-                          (_, i) => (
-                            <div
-                              key={i}
-                              style={{
-                                width: `${(30 / totalDays) * 100}%`,
-                                borderRight: "1px solid #f0f0f0",
-                              }}
-                            />
-                          )
-                        )
-                      : Array.from(
-                          { length: Math.ceil(totalDays / 7) },
-                          (_, i) => (
-                            <div
-                              key={i}
-                              style={{
-                                width: `${(7 / totalDays) * 100}%`,
-                                borderRight: "1px solid #f0f0f0",
-                              }}
-                            />
-                          )
-                        )}
+                  <div style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    display: 'flex'
+                  }}>
+                    {timelineView === 'week' ? (
+                      Array.from({ length: totalDays }, (_, i) => (
+                        <div
+                          key={i}
+                          style={{
+                            width: `${(1 / totalDays) * 100}%`,
+                            borderRight: '1px solid #f0f0f0'
+                          }}
+                        />
+                      ))
+                    ) : timelineView === 'quarter' ? (
+                      Array.from({ length: Math.ceil(totalDays / 30) }, (_, i) => (
+                        <div
+                          key={i}
+                          style={{
+                            width: `${(30 / totalDays) * 100}%`,
+                            borderRight: '1px solid #f0f0f0'
+                          }}
+                        />
+                      ))
+                    ) : (
+                      Array.from({ length: Math.ceil(totalDays / 7) }, (_, i) => (
+                        <div
+                          key={i}
+                          style={{
+                            width: `${(7 / totalDays) * 100}%`,
+                            borderRight: '1px solid #f0f0f0'
+                          }}
+                        />
+                      ))
+                    )}
                   </div>
 
                   {/* Progress Bar */}
                   <div
                     style={{
-                      position: "absolute",
-                      top: "50%",
-                      transform: "translateY(-50%)",
-                      height: item.type === "project" ? "24px" : "18px",
+                      position: 'absolute',
+                      top: '50%',
+                      transform: 'translateY(-50%)',
+                      height: item.type === 'project' ? '24px' : '18px',
                       backgroundColor: getStatusColor(item.status, item.type),
-                      borderRadius: "4px",
-                      display: "flex",
-                      alignItems: "center",
-                      boxShadow: "0 2px 4px rgba(0,0,0,0.1)",
-                      ...calculateBarStyle(item),
+                      borderRadius: '4px',
+                      display: 'flex',
+                      alignItems: 'center',
+                      boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+                      ...calculateBarStyle(item)
                     }}
                   >
                     {/* Progress Fill */}
                     <div
                       style={{
-                        height: "100%",
+                        height: '100%',
                         width: `${item.progress}%`,
-                        backgroundColor:
-                          item.status === "completed" ? "#52c41a" : "#1890ff",
-                        borderRadius: "4px",
-                        opacity: 0.8,
+                        backgroundColor: item.status === 'completed' ? '#52c41a' : '#1890ff',
+                        borderRadius: '4px',
+                        opacity: 0.8
                       }}
                     />
-
+                    
                     {/* Progress Text */}
-                    <div
-                      style={{
-                        position: "absolute",
-                        left: "50%",
-                        transform: "translateX(-50%)",
-                        fontSize: "10px",
-                        color: "#fff",
-                        fontWeight: "bold",
-                        textShadow: "0 1px 2px rgba(0,0,0,0.5)",
-                      }}
-                    >
+                    <div style={{
+                      position: 'absolute',
+                      left: '50%',
+                      transform: 'translateX(-50%)',
+                      fontSize: '10px',
+                      color: '#fff',
+                      fontWeight: 'bold',
+                      textShadow: '0 1px 2px rgba(0,0,0,0.5)'
+                    }}>
                       {item.progress}%
                     </div>
                   </div>
-                  {item.type === "task" &&
-                    (() => {
-                      const taskId = parseInt(item.id.replace("task-", ""));
-                      const { dependencies } = getTaskDependencies(taskId);
-                      const canStart = canStartTask(taskId);
-                      return (
-                        <>
-                          {dependencies.length > 0 && (
-                            <LinkOutlined
-                              style={{
-                                marginRight: 4,
-                                color: "#1890ff",
-                                fontSize: "12px",
-                              }}
-                            />
-                          )}
-                          {!canStart && (
-                            <ExclamationCircleOutlined
-                              style={{
-                                marginRight: 4,
-                                color: "#faad14",
-                                fontSize: "12px",
-                              }}
-                            />
-                          )}
-                        </>
-                      );
-                    })()}
+                                  {item.type === 'task' && (() => {
+                                    const taskId = parseInt(item.id.replace('task-', ''));
+                                    const { dependencies } = getTaskDependencies(taskId);
+                                    const canStart = canStartTask(taskId);
+                                    return (
+                                      <>
+                                        {dependencies.length > 0 && (
+                                          <LinkOutlined style={{ marginRight: 4, color: '#1890ff', fontSize: '12px' }} />
+                                        )}
+                                        {!canStart && (
+                                          <ExclamationCircleOutlined style={{ marginRight: 4, color: '#faad14', fontSize: '12px' }} />
+                                        )}
+                                      </>
+                                    );
+                                  })()}
 
                   {/* Today Line */}
                   {(() => {
                     const today = dayjs();
-                    if (
-                      today.isAfter(timelineStart) &&
-                      today.isBefore(timelineEnd)
-                    ) {
-                      const todayOffset = today.diff(timelineStart, "days");
+                    if (today.isAfter(timelineStart) && today.isBefore(timelineEnd)) {
+                      const todayOffset = today.diff(timelineStart, 'days');
                       const todayPosition = (todayOffset / totalDays) * 100;
-
+                      
                       return (
                         <div
                           style={{
-                            position: "absolute",
+                            position: 'absolute',
                             left: `${todayPosition}%`,
                             top: 0,
                             bottom: 0,
-                            width: "2px",
-                            backgroundColor: "#f5222d",
-                            zIndex: 5,
+                            width: '2px',
+                            backgroundColor: '#f5222d',
+                            zIndex: 5
                           }}
                         />
                       );
@@ -827,71 +704,42 @@ const GanttChart: React.FC = () => {
         </div>
 
         {/* Legend */}
-        <div
-          style={{
-            marginTop: 16,
-            padding: "12px",
-            backgroundColor: "#f9f9f9",
-            borderRadius: "6px",
-            display: "flex",
-            flexWrap: "wrap",
-            gap: "16px",
-            fontSize: "12px",
-          }}
-        >
-          <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
-            <div
-              style={{
-                width: "12px",
-                height: "12px",
-                backgroundColor: "#1890ff",
-                borderRadius: "2px",
-              }}
-            />
+        <div style={{ 
+          marginTop: 16,
+          padding: '12px',
+          backgroundColor: '#f9f9f9',
+          borderRadius: '6px',
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '16px',
+          fontSize: '12px'
+        }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+            <div style={{ width: '12px', height: '12px', backgroundColor: '#1890ff', borderRadius: '2px' }} />
             <span>In Progress</span>
           </div>
-          <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
-            <div
-              style={{
-                width: "12px",
-                height: "12px",
-                backgroundColor: "#52c41a",
-                borderRadius: "2px",
-              }}
-            />
+          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+            <div style={{ width: '12px', height: '12px', backgroundColor: '#52c41a', borderRadius: '2px' }} />
             <span>Completed</span>
           </div>
-          <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
-            <div
-              style={{
-                width: "12px",
-                height: "12px",
-                backgroundColor: "#faad14",
-                borderRadius: "2px",
-              }}
-            />
+          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+            <div style={{ width: '12px', height: '12px', backgroundColor: '#faad14', borderRadius: '2px' }} />
             <span>Planning/On Hold</span>
           </div>
-          <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
-            <div
-              style={{
-                width: "2px",
-                height: "12px",
-                backgroundColor: "#f5222d",
-              }}
-            />
+          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+            <div style={{ width: '2px', height: '12px', backgroundColor: '#f5222d' }} />
             <span>Today</span>
           </div>
-          <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
-            <ProjectOutlined style={{ color: "#1890ff" }} />
+          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+            <ProjectOutlined style={{ color: '#1890ff' }} />
             <span>Project</span>
           </div>
-          <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
-            <LinkOutlined style={{ color: "#1890ff" }} />
+          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+            <LinkOutlined style={{ color: '#1890ff' }} />
             <span>Has Dependencies</span>
           </div>
-          <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
-            <ExclamationCircleOutlined style={{ color: "#faad14" }} />
+          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+            <ExclamationCircleOutlined style={{ color: '#faad14' }} />
             <span>Waiting for Dependencies</span>
           </div>
         </div>

--- a/src/components/GanttChart.tsx
+++ b/src/components/GanttChart.tsx
@@ -153,7 +153,7 @@ const GanttChart: React.FC = () => {
       );
 
       weeks.push({
-        label: `W ${current.week()} (${current.format('MMM DD')} - ${weekEnd.format('MMM DD')})`,
+        label: `Week ${current.week()} (${current.format('MMM DD')} - ${weekEnd.format('MMM DD')})`,
         days: daysInWeek,
         width: (daysInWeek / totalDays) * 100
       });

--- a/src/components/GanttChart.tsx
+++ b/src/components/GanttChart.tsx
@@ -688,16 +688,16 @@ const GanttChart: React.FC = () => {
                   >
                     {timelineView === "week"
                       ? Array.from({ length: totalDays }, (_, i) => (
-                        <div
-                          key={i}
-                          style={{
-                            width: `${(1 / totalDays) * 100}%`,
-                            borderRight: "1px solid #f0f0f0",
-                          }}
-                        />
-                      ))
+                          <div
+                            key={i}
+                            style={{
+                              width: `${(1 / totalDays) * 100}%`,
+                              borderRight: "1px solid #f0f0f0",
+                            }}
+                          />
+                        ))
                       : timelineView === "quarter"
-                        ? Array.from(
+                      ? Array.from(
                           { length: Math.ceil(totalDays / 30) },
                           (_, i) => (
                             <div
@@ -709,7 +709,7 @@ const GanttChart: React.FC = () => {
                             />
                           )
                         )
-                        : Array.from(
+                      : Array.from(
                           { length: Math.ceil(totalDays / 7) },
                           (_, i) => (
                             <div

--- a/src/components/GanttChart.tsx
+++ b/src/components/GanttChart.tsx
@@ -29,6 +29,7 @@ const GanttChart: React.FC = () => {
   const [selectedProjectId, setSelectedProjectId] = useState<number | null>(null);
   const [selectedStatus, setSelectedStatus] = useState<string | null>(null);
   const [dateRange, setDateRange] = useState<[dayjs.Dayjs | null, dayjs.Dayjs | null] | null>(null);
+  const [timelineView, setTimelineView] = useState<'week' | 'month' | 'quarter'>('month');
 
   // Filter data based on user role
   let userProjects = user?.role === 'admin'
@@ -127,30 +128,90 @@ const GanttChart: React.FC = () => {
   const { start: timelineStart, end: timelineEnd } = getTimelineBounds();
   const totalDays = timelineEnd.diff(timelineStart, 'days');
 
+  // Generate timeline headers based on view type
+  const generateTimelineHeaders = () => {
+    switch (timelineView) {
+      case 'week':
+        return generateWeekHeaders();
+      case 'quarter':
+        return generateQuarterHeaders();
+      default:
+        return generateMonthHeaders();
+    }
+  };
+
+  // Generate week headers
+  const generateWeekHeaders = () => {
+    const weeks = [];
+    let current = timelineStart.startOf('week');
+
+    while (current.isBefore(timelineEnd)) {
+      const weekEnd = current.endOf('week');
+      const daysInWeek = Math.min(
+        7,
+        timelineEnd.diff(current, 'days') + 1
+      );
+
+      weeks.push({
+        label: `Week ${current.week()} (${current.format('MMM DD')} - ${weekEnd.format('MMM DD')})`,
+        days: daysInWeek,
+        width: (daysInWeek / totalDays) * 100
+      });
+
+      current = current.add(1, 'week');
+    }
+
+    return weeks;
+  };
+
   // Generate month headers
   const generateMonthHeaders = () => {
     const months = [];
     let current = timelineStart.startOf('month');
-    
+
     while (current.isBefore(timelineEnd)) {
       const daysInMonth = Math.min(
         current.daysInMonth(),
         timelineEnd.diff(current, 'days') + 1
       );
-      
+
       months.push({
         label: current.format('MMM YYYY'),
         days: daysInMonth,
         width: (daysInMonth / totalDays) * 100
       });
-      
+
       current = current.add(1, 'month');
     }
-    
+
     return months;
   };
 
-  const monthHeaders = generateMonthHeaders();
+  // Generate quarter headers
+  const generateQuarterHeaders = () => {
+    const quarters = [];
+    let current = timelineStart.startOf('quarter');
+
+    while (current.isBefore(timelineEnd)) {
+      const quarterEnd = current.endOf('quarter');
+      const daysInQuarter = Math.min(
+        quarterEnd.diff(current, 'days') + 1,
+        timelineEnd.diff(current, 'days') + 1
+      );
+
+      quarters.push({
+        label: `Q${current.quarter()} ${current.format('YYYY')} (${current.format('MMM')} - ${quarterEnd.format('MMM')})`,
+        days: daysInQuarter,
+        width: (daysInQuarter / totalDays) * 100
+      });
+
+      current = current.add(1, 'quarter');
+    }
+
+    return quarters;
+  };
+
+  const timelineHeaders = generateTimelineHeaders();
 
   // Calculate bar position and width
   const calculateBarStyle = (item: any) => {
@@ -201,7 +262,11 @@ const GanttChart: React.FC = () => {
           <CalendarOutlined /> Project Timeline (Gantt Chart)
         </Title>
         <Space>
-          <Select defaultValue="month" style={{ width: 120 }}>
+          <Select
+            value={timelineView}
+            onChange={(value) => setTimelineView(value)}
+            style={{ width: 120 }}
+          >
             <Option value="week">Week View</Option>
             <Option value="month">Month View</Option>
             <Option value="quarter">Quarter View</Option>
@@ -344,52 +409,112 @@ const GanttChart: React.FC = () => {
 
             {/* Timeline Header */}
             <div style={{ flex: 1, minWidth: '800px' }}>
-              {/* Month Headers */}
-              <div style={{ 
+              {/* Timeline Headers */}
+              <div style={{
                 display: 'flex',
                 borderBottom: '1px solid #e8e8e8',
                 backgroundColor: '#f5f5f5'
               }}>
-                {monthHeaders.map((month, index) => (
+                {timelineHeaders.map((header, index) => (
                   <div
                     key={index}
                     style={{
-                      width: `${month.width}%`,
+                      width: `${header.width}%`,
                       padding: '8px 4px',
                       textAlign: 'center',
-                      fontSize: '12px',
+                      fontSize: timelineView === 'week' ? '10px' : '12px',
                       fontWeight: 'bold',
-                      borderRight: index < monthHeaders.length - 1 ? '1px solid #e8e8e8' : 'none'
+                      borderRight: index < timelineHeaders.length - 1 ? '1px solid #e8e8e8' : 'none',
+                      minHeight: '32px',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center'
                     }}
                   >
-                    {month.label}
+                    {header.label}
                   </div>
                 ))}
               </div>
 
-              {/* Week Grid */}
-              <div style={{ 
-                display: 'flex',
-                height: '30px',
-                backgroundColor: '#f9f9f9'
-              }}>
-                {Array.from({ length: Math.ceil(totalDays / 7) }, (_, i) => (
-                  <div
-                    key={i}
-                    style={{
-                      width: `${(7 / totalDays) * 100}%`,
-                      borderRight: '1px solid #e8e8e8',
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      fontSize: '10px',
-                      color: '#666'
-                    }}
-                  >
-                    W{i + 1}
-                  </div>
-                ))}
-              </div>
+              {/* Sub-grid based on view type */}
+              {timelineView === 'month' && (
+                <div style={{
+                  display: 'flex',
+                  height: '30px',
+                  backgroundColor: '#f9f9f9'
+                }}>
+                  {Array.from({ length: Math.ceil(totalDays / 7) }, (_, i) => (
+                    <div
+                      key={i}
+                      style={{
+                        width: `${(7 / totalDays) * 100}%`,
+                        borderRight: '1px solid #e8e8e8',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        fontSize: '10px',
+                        color: '#666'
+                      }}
+                    >
+                      W{i + 1}
+                    </div>
+                  ))}
+                </div>
+              )}
+              {timelineView === 'week' && (
+                <div style={{
+                  display: 'flex',
+                  height: '30px',
+                  backgroundColor: '#f9f9f9'
+                }}>
+                  {Array.from({ length: totalDays }, (_, i) => {
+                    const date = timelineStart.add(i, 'day');
+                    return (
+                      <div
+                        key={i}
+                        style={{
+                          width: `${(1 / totalDays) * 100}%`,
+                          borderRight: '1px solid #e8e8e8',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          fontSize: '9px',
+                          color: '#666'
+                        }}
+                      >
+                        {date.format('DD')}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+              {timelineView === 'quarter' && (
+                <div style={{
+                  display: 'flex',
+                  height: '30px',
+                  backgroundColor: '#f9f9f9'
+                }}>
+                  {Array.from({ length: Math.ceil(totalDays / 30) }, (_, i) => {
+                    const monthStart = timelineStart.add(i * 30, 'day');
+                    return (
+                      <div
+                        key={i}
+                        style={{
+                          width: `${(30 / totalDays) * 100}%`,
+                          borderRight: '1px solid #e8e8e8',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          fontSize: '10px',
+                          color: '#666'
+                        }}
+                      >
+                        {monthStart.format('MMM')}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
             </div>
           </div>
 
@@ -461,15 +586,37 @@ const GanttChart: React.FC = () => {
                     bottom: 0,
                     display: 'flex'
                   }}>
-                    {Array.from({ length: Math.ceil(totalDays / 7) }, (_, i) => (
-                      <div
-                        key={i}
-                        style={{
-                          width: `${(7 / totalDays) * 100}%`,
-                          borderRight: '1px solid #f0f0f0'
-                        }}
-                      />
-                    ))}
+                    {timelineView === 'week' ? (
+                      Array.from({ length: totalDays }, (_, i) => (
+                        <div
+                          key={i}
+                          style={{
+                            width: `${(1 / totalDays) * 100}%`,
+                            borderRight: '1px solid #f0f0f0'
+                          }}
+                        />
+                      ))
+                    ) : timelineView === 'quarter' ? (
+                      Array.from({ length: Math.ceil(totalDays / 30) }, (_, i) => (
+                        <div
+                          key={i}
+                          style={{
+                            width: `${(30 / totalDays) * 100}%`,
+                            borderRight: '1px solid #f0f0f0'
+                          }}
+                        />
+                      ))
+                    ) : (
+                      Array.from({ length: Math.ceil(totalDays / 7) }, (_, i) => (
+                        <div
+                          key={i}
+                          style={{
+                            width: `${(7 / totalDays) * 100}%`,
+                            borderRight: '1px solid #f0f0f0'
+                          }}
+                        />
+                      ))
+                    )}
                   </div>
 
                   {/* Progress Bar */}

--- a/src/components/GanttChart.tsx
+++ b/src/components/GanttChart.tsx
@@ -1,18 +1,27 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { Card, Typography, Space, Button, Select, DatePicker, Row, Col } from 'antd';
-import { 
-  CalendarOutlined, 
-  ProjectOutlined, 
+import React, { useEffect, useRef, useState } from "react";
+import {
+  Card,
+  Typography,
+  Space,
+  Button,
+  Select,
+  DatePicker,
+  Row,
+  Col,
+} from "antd";
+import {
+  CalendarOutlined,
+  ProjectOutlined,
   FullscreenOutlined,
   ZoomInOutlined,
   ZoomOutOutlined,
   LinkOutlined,
-  ExclamationCircleOutlined
-} from '@ant-design/icons';
-import { useData } from '../contexts/DataContext';
-import { useAuth } from '../contexts/AuthContext';
-import dayjs from 'dayjs';
-import minMax from 'dayjs/plugin/minMax';
+  ExclamationCircleOutlined,
+} from "@ant-design/icons";
+import { useData } from "../contexts/DataContext";
+import { useAuth } from "../contexts/AuthContext";
+import dayjs from "dayjs";
+import minMax from "dayjs/plugin/minMax";
 
 dayjs.extend(minMax);
 
@@ -26,31 +35,39 @@ const GanttChart: React.FC = () => {
   const ganttRef = useRef<HTMLDivElement>(null);
 
   // Filter states
-  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(null);
+  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(
+    null
+  );
   const [selectedStatus, setSelectedStatus] = useState<string | null>(null);
-  const [dateRange, setDateRange] = useState<[dayjs.Dayjs | null, dayjs.Dayjs | null] | null>(null);
-  const [timelineView, setTimelineView] = useState<'week' | 'month' | 'quarter'>('month');
+  const [dateRange, setDateRange] = useState<
+    [dayjs.Dayjs | null, dayjs.Dayjs | null] | null
+  >(null);
+  const [timelineView, setTimelineView] = useState<
+    "week" | "month" | "quarter"
+  >("month");
 
   // Filter data based on user role
-  let userProjects = user?.role === 'admin'
-    ? projects
-    : projects.filter(p => user?.projectIds?.includes(p.id));
+  let userProjects =
+    user?.role === "admin"
+      ? projects
+      : projects.filter((p) => user?.projectIds?.includes(p.id));
 
-  let userTasks = user?.role === 'executive'
-    ? tasks.filter(t => t.assignedTo === user.id)
-    : tasks.filter(t => userProjects.some(p => p.id === t.projectId));
+  let userTasks =
+    user?.role === "executive"
+      ? tasks.filter((t) => t.assignedTo === user.id)
+      : tasks.filter((t) => userProjects.some((p) => p.id === t.projectId));
 
   // Apply timeline filters
   // 1. Project filter - when selected, show only that project
   if (selectedProjectId) {
-    userProjects = userProjects.filter(p => p.id === selectedProjectId);
-    userTasks = userTasks.filter(t => t.projectId === selectedProjectId);
+    userProjects = userProjects.filter((p) => p.id === selectedProjectId);
+    userTasks = userTasks.filter((t) => t.projectId === selectedProjectId);
   }
 
   // 2. Status filter - apply to both projects and tasks
   if (selectedStatus) {
-    userProjects = userProjects.filter(p => p.status === selectedStatus);
-    userTasks = userTasks.filter(t => t.status === selectedStatus);
+    userProjects = userProjects.filter((p) => p.status === selectedStatus);
+    userTasks = userTasks.filter((t) => t.status === selectedStatus);
   }
 
   // 3. Date range filter - show items that overlap with selected date range
@@ -58,18 +75,24 @@ const GanttChart: React.FC = () => {
     const startDate = dateRange[0];
     const endDate = dateRange[1];
 
-    userProjects = userProjects.filter(p => {
+    userProjects = userProjects.filter((p) => {
       const projectStart = dayjs(p.startDate);
       const projectEnd = dayjs(p.endDate);
       // Check if project dates overlap with filter range
-      return projectStart.isBefore(endDate.add(1, 'day')) && projectEnd.isAfter(startDate.subtract(1, 'day'));
+      return (
+        projectStart.isBefore(endDate.add(1, "day")) &&
+        projectEnd.isAfter(startDate.subtract(1, "day"))
+      );
     });
 
-    userTasks = userTasks.filter(t => {
+    userTasks = userTasks.filter((t) => {
       const taskStart = dayjs(t.createdDate);
       const taskEnd = dayjs(t.dueDate);
       // Check if task dates overlap with filter range
-      return taskStart.isBefore(endDate.add(1, 'day')) && taskEnd.isAfter(startDate.subtract(1, 'day'));
+      return (
+        taskStart.isBefore(endDate.add(1, "day")) &&
+        taskEnd.isAfter(startDate.subtract(1, "day"))
+      );
     });
   }
 
@@ -79,29 +102,29 @@ const GanttChart: React.FC = () => {
   // Generate timeline data
   const generateTimelineData = () => {
     const allItems = [
-      ...userProjects.map(project => ({
+      ...userProjects.map((project) => ({
         id: `project-${project.id}`,
         name: project.name,
-        type: 'project',
+        type: "project",
         start: dayjs(project.startDate),
         end: dayjs(project.endDate),
         progress: project.progress,
         status: project.status,
         parent: null,
-        level: 0
+        level: 0,
       })),
-      ...userTasks.map(task => ({
+      ...userTasks.map((task) => ({
         id: `task-${task.id}`,
         name: task.title,
-        type: 'task',
+        type: "task",
         start: dayjs(task.createdDate),
         end: dayjs(task.dueDate),
         progress: task.progress,
         status: task.status,
         parent: `project-${task.projectId}`,
         level: 1,
-        priority: task.priority
-      }))
+        priority: task.priority,
+      })),
     ];
 
     return allItems.sort((a, b) => {
@@ -114,26 +137,27 @@ const GanttChart: React.FC = () => {
 
   // Calculate timeline bounds
   const getTimelineBounds = () => {
-    if (timelineData.length === 0) return { start: dayjs(), end: dayjs().add(1, 'month') };
-    
-    const starts = timelineData.map(item => item.start);
-    const ends = timelineData.map(item => item.end);
-    
-    const minStart = dayjs.min(starts)?.subtract(1, 'week') || dayjs();
-    const maxEnd = dayjs.max(ends)?.add(1, 'week') || dayjs().add(1, 'month');
-    
+    if (timelineData.length === 0)
+      return { start: dayjs(), end: dayjs().add(1, "month") };
+
+    const starts = timelineData.map((item) => item.start);
+    const ends = timelineData.map((item) => item.end);
+
+    const minStart = dayjs.min(starts)?.subtract(1, "week") || dayjs();
+    const maxEnd = dayjs.max(ends)?.add(1, "week") || dayjs().add(1, "month");
+
     return { start: minStart, end: maxEnd };
   };
 
   const { start: timelineStart, end: timelineEnd } = getTimelineBounds();
-  const totalDays = timelineEnd.diff(timelineStart, 'days');
+  const totalDays = timelineEnd.diff(timelineStart, "days");
 
   // Generate timeline headers based on view type
   const generateTimelineHeaders = () => {
     switch (timelineView) {
-      case 'week':
+      case "week":
         return generateWeekHeaders();
-      case 'quarter':
+      case "quarter":
         return generateQuarterHeaders();
       default:
         return generateMonthHeaders();
@@ -143,22 +167,21 @@ const GanttChart: React.FC = () => {
   // Generate week headers
   const generateWeekHeaders = () => {
     const weeks = [];
-    let current = timelineStart.startOf('week');
+    let current = timelineStart.startOf("week");
 
     while (current.isBefore(timelineEnd)) {
-      const weekEnd = current.endOf('week');
-      const daysInWeek = Math.min(
-        7,
-        timelineEnd.diff(current, 'days') + 1
-      );
+      const weekEnd = current.endOf("week");
+      const daysInWeek = Math.min(7, timelineEnd.diff(current, "days") + 1);
 
       weeks.push({
-        label: `Week ${current.week()} (${current.format('MMM DD')} - ${weekEnd.format('MMM DD')})`,
+        label: `Week ${current.week()} (${current.format(
+          "MMM DD"
+        )} - ${weekEnd.format("MMM DD")})`,
         days: daysInWeek,
-        width: (daysInWeek / totalDays) * 100
+        width: (daysInWeek / totalDays) * 100,
       });
 
-      current = current.add(1, 'week');
+      current = current.add(1, "week");
     }
 
     return weeks;
@@ -167,21 +190,21 @@ const GanttChart: React.FC = () => {
   // Generate month headers
   const generateMonthHeaders = () => {
     const months = [];
-    let current = timelineStart.startOf('month');
+    let current = timelineStart.startOf("month");
 
     while (current.isBefore(timelineEnd)) {
       const daysInMonth = Math.min(
         current.daysInMonth(),
-        timelineEnd.diff(current, 'days') + 1
+        timelineEnd.diff(current, "days") + 1
       );
 
       months.push({
-        label: current.format('MMM YYYY'),
+        label: current.format("MMM YYYY"),
         days: daysInMonth,
-        width: (daysInMonth / totalDays) * 100
+        width: (daysInMonth / totalDays) * 100,
       });
 
-      current = current.add(1, 'month');
+      current = current.add(1, "month");
     }
 
     return months;
@@ -190,22 +213,24 @@ const GanttChart: React.FC = () => {
   // Generate quarter headers
   const generateQuarterHeaders = () => {
     const quarters = [];
-    let current = timelineStart.startOf('quarter');
+    let current = timelineStart.startOf("quarter");
 
     while (current.isBefore(timelineEnd)) {
-      const quarterEnd = current.endOf('quarter');
+      const quarterEnd = current.endOf("quarter");
       const daysInQuarter = Math.min(
-        quarterEnd.diff(current, 'days') + 1,
-        timelineEnd.diff(current, 'days') + 1
+        quarterEnd.diff(current, "days") + 1,
+        timelineEnd.diff(current, "days") + 1
       );
 
       quarters.push({
-        label: `Q${current.quarter()} ${current.format('YYYY')} (${current.format('MMM')} - ${quarterEnd.format('MMM')})`,
+        label: `Q${current.quarter()} ${current.format(
+          "YYYY"
+        )} (${current.format("MMM")} - ${quarterEnd.format("MMM")})`,
         days: daysInQuarter,
-        width: (daysInQuarter / totalDays) * 100
+        width: (daysInQuarter / totalDays) * 100,
       });
 
-      current = current.add(1, 'quarter');
+      current = current.add(1, "quarter");
     }
 
     return quarters;
@@ -215,49 +240,51 @@ const GanttChart: React.FC = () => {
 
   // Calculate bar position and width
   const calculateBarStyle = (item: any) => {
-    const startOffset = item.start.diff(timelineStart, 'days');
-    const duration = item.end.diff(item.start, 'days') + 1;
-    
+    const startOffset = item.start.diff(timelineStart, "days");
+    const duration = item.end.diff(item.start, "days") + 1;
+
     const left = (startOffset / totalDays) * 100;
     const width = (duration / totalDays) * 100;
-    
+
     return { left: `${left}%`, width: `${width}%` };
   };
 
   // Get status color
   const getStatusColor = (status: string, type: string) => {
-    if (type === 'project') {
+    if (type === "project") {
       const colors = {
-        'planning': '#faad14',
-        'in-progress': '#1890ff',
-        'completed': '#52c41a',
-        'on-hold': '#f5222d'
+        planning: "#faad14",
+        "in-progress": "#1890ff",
+        completed: "#52c41a",
+        "on-hold": "#f5222d",
       };
-      return colors[status as keyof typeof colors] || '#d9d9d9';
+      return colors[status as keyof typeof colors] || "#d9d9d9";
     } else {
       const colors = {
-        'not-started': '#d9d9d9',
-        'in-progress': '#1890ff',
-        'completed': '#52c41a',
-        'on-hold': '#faad14'
+        "not-started": "#d9d9d9",
+        "in-progress": "#1890ff",
+        completed: "#52c41a",
+        "on-hold": "#faad14",
       };
-      return colors[status as keyof typeof colors] || '#d9d9d9';
+      return colors[status as keyof typeof colors] || "#d9d9d9";
     }
   };
 
   const getPriorityColor = (priority?: string) => {
-    const colors = { high: '#f5222d', medium: '#faad14', low: '#52c41a' };
-    return colors[priority as keyof typeof colors] || '#1890ff';
+    const colors = { high: "#f5222d", medium: "#faad14", low: "#52c41a" };
+    return colors[priority as keyof typeof colors] || "#1890ff";
   };
 
   return (
     <div>
-      <div style={{ 
-        display: 'flex', 
-        justifyContent: 'space-between', 
-        alignItems: 'center',
-        marginBottom: 24
-      }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 24,
+        }}
+      >
         <Title level={2} style={{ margin: 0 }}>
           <CalendarOutlined /> Project Timeline (Gantt Chart)
         </Title>
@@ -280,39 +307,71 @@ const GanttChart: React.FC = () => {
       <Card>
         <div style={{ marginBottom: 16 }}>
           {/* Filter Status */}
-          <div style={{
-            marginBottom: 12,
-            padding: '8px 12px',
-            backgroundColor: (selectedProjectId || selectedStatus || dateRange) ? '#f6ffed' : '#f5f5f5',
-            border: (selectedProjectId || selectedStatus || dateRange) ? '1px solid #b7eb8f' : '1px solid #d9d9d9',
-            borderRadius: '4px',
-            fontSize: '12px'
-          }}>
+          <div
+            style={{
+              marginBottom: 12,
+              padding: "8px 12px",
+              backgroundColor:
+                selectedProjectId || selectedStatus || dateRange
+                  ? "#f6ffed"
+                  : "#f5f5f5",
+              border:
+                selectedProjectId || selectedStatus || dateRange
+                  ? "1px solid #b7eb8f"
+                  : "1px solid #d9d9d9",
+              borderRadius: "4px",
+              fontSize: "12px",
+            }}
+          >
             <Space>
-              {(selectedProjectId || selectedStatus || dateRange) ? (
+              {selectedProjectId || selectedStatus || dateRange ? (
                 <>
                   <span>Active Filters:</span>
                   {selectedProjectId && (
-                    <span style={{ background: '#52c41a', color: '#fff', padding: '2px 6px', borderRadius: '2px' }}>
-                      Project: {projects.find(p => p.id === selectedProjectId)?.name}
+                    <span
+                      style={{
+                        background: "#52c41a",
+                        color: "#fff",
+                        padding: "2px 6px",
+                        borderRadius: "2px",
+                      }}
+                    >
+                      Project:{" "}
+                      {projects.find((p) => p.id === selectedProjectId)?.name}
                     </span>
                   )}
                   {selectedStatus && (
-                    <span style={{ background: '#1890ff', color: '#fff', padding: '2px 6px', borderRadius: '2px' }}>
+                    <span
+                      style={{
+                        background: "#1890ff",
+                        color: "#fff",
+                        padding: "2px 6px",
+                        borderRadius: "2px",
+                      }}
+                    >
                       Status: {selectedStatus}
                     </span>
                   )}
                   {dateRange && dateRange[0] && dateRange[1] && (
-                    <span style={{ background: '#722ed1', color: '#fff', padding: '2px 6px', borderRadius: '2px' }}>
-                      Date: {dateRange[0].format('MMM DD')} - {dateRange[1].format('MMM DD')}
+                    <span
+                      style={{
+                        background: "#722ed1",
+                        color: "#fff",
+                        padding: "2px 6px",
+                        borderRadius: "2px",
+                      }}
+                    >
+                      Date: {dateRange[0].format("MMM DD")} -{" "}
+                      {dateRange[1].format("MMM DD")}
                     </span>
                   )}
                 </>
               ) : (
                 <span>No filters applied - showing all data</span>
               )}
-              <span style={{ color: '#666' }}>
-                | Showing: {userProjects.length} projects, {userTasks.length} tasks
+              <span style={{ color: "#666" }}>
+                | Showing: {userProjects.length} projects, {userTasks.length}{" "}
+                tasks
               </span>
             </Space>
           </div>
@@ -321,22 +380,27 @@ const GanttChart: React.FC = () => {
             <Col xs={24} sm={6}>
               <Select
                 placeholder="Filter by Project (All by default)"
-                style={{ width: '100%' }}
+                style={{ width: "100%" }}
                 allowClear
                 value={selectedProjectId}
                 onChange={(value) => setSelectedProjectId(value)}
               >
-                {projects.filter(p => user?.role === 'admin' || user?.projectIds?.includes(p.id)).map(project => (
-                  <Option key={project.id} value={project.id}>
-                    {project.name}
-                  </Option>
-                ))}
+                {projects
+                  .filter(
+                    (p) =>
+                      user?.role === "admin" || user?.projectIds?.includes(p.id)
+                  )
+                  .map((project) => (
+                    <Option key={project.id} value={project.id}>
+                      {project.name}
+                    </Option>
+                  ))}
               </Select>
             </Col>
             <Col xs={24} sm={6}>
               <Select
                 placeholder="Filter by Status (All by default)"
-                style={{ width: '100%' }}
+                style={{ width: "100%" }}
                 allowClear
                 value={selectedStatus}
                 onChange={(value) => setSelectedStatus(value)}
@@ -350,8 +414,8 @@ const GanttChart: React.FC = () => {
             </Col>
             <Col xs={24} sm={6}>
               <DatePicker.RangePicker
-                style={{ width: '100%' }}
-                placeholder={['Start Date', 'End Date']}
+                style={{ width: "100%" }}
+                placeholder={["Start Date", "End Date"]}
                 value={dateRange}
                 onChange={(dates) => setDateRange(dates)}
               />
@@ -363,7 +427,7 @@ const GanttChart: React.FC = () => {
                   setSelectedStatus(null);
                   setDateRange(null);
                 }}
-                style={{ width: '100%' }}
+                style={{ width: "100%" }}
               >
                 Clear Filters
               </Button>
@@ -371,64 +435,75 @@ const GanttChart: React.FC = () => {
           </Row>
         </div>
 
-        <div 
+        <div
           ref={ganttRef}
-          style={{ 
-            border: '1px solid #f0f0f0',
-            borderRadius: '6px',
-            overflow: 'auto',
-            minHeight: '500px',
-            backgroundColor: '#fafafa'
+          style={{
+            border: "1px solid #f0f0f0",
+            borderRadius: "6px",
+            overflow: "auto",
+            minHeight: "500px",
+            backgroundColor: "#fafafa",
           }}
         >
           {/* Header */}
-          <div style={{ 
-            display: 'flex',
-            borderBottom: '2px solid #e8e8e8',
-            backgroundColor: '#fff',
-            position: 'sticky',
-            top: 0,
-            zIndex: 10
-          }}>
+          <div
+            style={{
+              display: "flex",
+              borderBottom: "2px solid #e8e8e8",
+              backgroundColor: "#fff",
+              position: "sticky",
+              top: 0,
+              zIndex: 10,
+            }}
+          >
             {/* Task Names Column */}
-            <div style={{ 
-              width: '300px',
-              minWidth: '300px',
-              borderRight: '2px solid #e8e8e8',
-              backgroundColor: '#fafafa'
-            }}>
-              <div style={{ 
-                padding: '12px 16px',
-                fontWeight: 'bold',
-                borderBottom: '1px solid #e8e8e8',
-                backgroundColor: '#f5f5f5'
-              }}>
+            <div
+              style={{
+                width: "300px",
+                minWidth: "300px",
+                borderRight: "2px solid #e8e8e8",
+                backgroundColor: "#fafafa",
+              }}
+            >
+              <div
+                style={{
+                  padding: "12px 16px",
+                  fontWeight: "bold",
+                  borderBottom: "1px solid #e8e8e8",
+                  backgroundColor: "#f5f5f5",
+                }}
+              >
                 Task / Project Name
               </div>
             </div>
 
             {/* Timeline Header */}
-            <div style={{ flex: 1, minWidth: '800px' }}>
+            <div style={{ flex: 1, minWidth: "800px" }}>
               {/* Timeline Headers */}
-              <div style={{
-                display: 'flex',
-                borderBottom: '1px solid #e8e8e8',
-                backgroundColor: '#f5f5f5'
-              }}>
+              <div
+                style={{
+                  display: "flex",
+                  borderBottom: "1px solid #e8e8e8",
+                  backgroundColor: "#f5f5f5",
+                }}
+              >
                 {timelineHeaders.map((header, index) => (
                   <div
                     key={index}
                     style={{
                       width: `${header.width}%`,
-                      padding: '8px 4px',
-                      textAlign: 'center',
-                      fontSize: timelineView === 'week' ? '10px' : '12px',
-                      fontWeight: 'bold',
-                      borderRight: index < timelineHeaders.length - 1 ? '1px solid #e8e8e8' : 'none',
-                      minHeight: '32px',
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center'
+                      padding: "8px 4px",
+                      textAlign: "center",
+                      fontSize: timelineView === "week" ? "10px" : "12px",
+                      fontWeight: "bold",
+                      borderRight:
+                        index < timelineHeaders.length - 1
+                          ? "1px solid #e8e8e8"
+                          : "none",
+                      minHeight: "32px",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
                     }}
                   >
                     {header.label}
@@ -437,23 +512,25 @@ const GanttChart: React.FC = () => {
               </div>
 
               {/* Sub-grid based on view type */}
-              {timelineView === 'month' && (
-                <div style={{
-                  display: 'flex',
-                  height: '30px',
-                  backgroundColor: '#f9f9f9'
-                }}>
+              {timelineView === "month" && (
+                <div
+                  style={{
+                    display: "flex",
+                    height: "30px",
+                    backgroundColor: "#f9f9f9",
+                  }}
+                >
                   {Array.from({ length: Math.ceil(totalDays / 7) }, (_, i) => (
                     <div
                       key={i}
                       style={{
                         width: `${(7 / totalDays) * 100}%`,
-                        borderRight: '1px solid #e8e8e8',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        fontSize: '10px',
-                        color: '#666'
+                        borderRight: "1px solid #e8e8e8",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        fontSize: "10px",
+                        color: "#666",
                       }}
                     >
                       W{i + 1}
@@ -461,55 +538,59 @@ const GanttChart: React.FC = () => {
                   ))}
                 </div>
               )}
-              {timelineView === 'week' && (
-                <div style={{
-                  display: 'flex',
-                  height: '30px',
-                  backgroundColor: '#f9f9f9'
-                }}>
+              {/* {timelineView === "week" && (
+                <div
+                  style={{
+                    display: "flex",
+                    height: "30px",
+                    backgroundColor: "#f9f9f9",
+                  }}
+                >
                   {Array.from({ length: totalDays }, (_, i) => {
-                    const date = timelineStart.add(i, 'day');
+                    const date = timelineStart.add(i, "day");
                     return (
                       <div
                         key={i}
                         style={{
                           width: `${(1 / totalDays) * 100}%`,
-                          borderRight: '1px solid #e8e8e8',
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          fontSize: '9px',
-                          color: '#666'
+                          borderRight: "1px solid #e8e8e8",
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          fontSize: "9px",
+                          color: "#666",
                         }}
                       >
-                        {date.format('DD')}
+                        {date.format("DD")}
                       </div>
                     );
                   })}
                 </div>
-              )}
-              {timelineView === 'quarter' && (
-                <div style={{
-                  display: 'flex',
-                  height: '30px',
-                  backgroundColor: '#f9f9f9'
-                }}>
+              )} */}
+              {timelineView === "quarter" && (
+                <div
+                  style={{
+                    display: "flex",
+                    height: "30px",
+                    backgroundColor: "#f9f9f9",
+                  }}
+                >
                   {Array.from({ length: Math.ceil(totalDays / 30) }, (_, i) => {
-                    const monthStart = timelineStart.add(i * 30, 'day');
+                    const monthStart = timelineStart.add(i * 30, "day");
                     return (
                       <div
                         key={i}
                         style={{
                           width: `${(30 / totalDays) * 100}%`,
-                          borderRight: '1px solid #e8e8e8',
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          fontSize: '10px',
-                          color: '#666'
+                          borderRight: "1px solid #e8e8e8",
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          fontSize: "10px",
+                          color: "#666",
                         }}
                       >
-                        {monthStart.format('MMM')}
+                        {monthStart.format("MMM")}
                       </div>
                     );
                   })}
@@ -524,45 +605,60 @@ const GanttChart: React.FC = () => {
               <div
                 key={item.id}
                 style={{
-                  display: 'flex',
-                  borderBottom: '1px solid #f0f0f0',
-                  minHeight: '50px',
-                  backgroundColor: index % 2 === 0 ? '#fff' : '#fafafa'
+                  display: "flex",
+                  borderBottom: "1px solid #f0f0f0",
+                  minHeight: "50px",
+                  backgroundColor: index % 2 === 0 ? "#fff" : "#fafafa",
                 }}
               >
                 {/* Task Name */}
-                <div style={{ 
-                  width: '300px',
-                  minWidth: '300px',
-                  borderRight: '1px solid #f0f0f0',
-                  padding: '12px 16px',
-                  display: 'flex',
-                  alignItems: 'center'
-                }}>
-                  <div style={{ 
-                    marginLeft: item.level * 20,
-                    width: '100%'
-                  }}>
-                    <div style={{ 
-                      fontWeight: item.type === 'project' ? 'bold' : 'normal',
-                      fontSize: item.type === 'project' ? '14px' : '13px',
-                      color: item.type === 'project' ? '#1890ff' : '#333',
-                      marginBottom: '2px'
-                    }}>
-                      {item.type === 'project' && <ProjectOutlined style={{ marginRight: 8 }} />}
-                      {item.name.length > 35 ? item.name.substring(0, 35) + '...' : item.name}
+                <div
+                  style={{
+                    width: "300px",
+                    minWidth: "300px",
+                    borderRight: "1px solid #f0f0f0",
+                    padding: "12px 16px",
+                    display: "flex",
+                    alignItems: "center",
+                  }}
+                >
+                  <div
+                    style={{
+                      marginLeft: item.level * 20,
+                      width: "100%",
+                    }}
+                  >
+                    <div
+                      style={{
+                        fontWeight: item.type === "project" ? "bold" : "normal",
+                        fontSize: item.type === "project" ? "14px" : "13px",
+                        color: item.type === "project" ? "#1890ff" : "#333",
+                        marginBottom: "2px",
+                      }}
+                    >
+                      {item.type === "project" && (
+                        <ProjectOutlined style={{ marginRight: 8 }} />
+                      )}
+                      {item.name.length > 35
+                        ? item.name.substring(0, 35) + "..."
+                        : item.name}
                     </div>
-                    <div style={{ 
-                      fontSize: '11px',
-                      color: '#666'
-                    }}>
-                      {item.start.format('MMM DD')} - {item.end.format('MMM DD, YYYY')}
-                      {item.type === 'task' && item.priority && (
-                        <span style={{ 
-                          marginLeft: 8,
-                          color: getPriorityColor(item.priority),
-                          fontWeight: 'bold'
-                        }}>
+                    <div
+                      style={{
+                        fontSize: "11px",
+                        color: "#666",
+                      }}
+                    >
+                      {item.start.format("MMM DD")} -{" "}
+                      {item.end.format("MMM DD, YYYY")}
+                      {item.type === "task" && item.priority && (
+                        <span
+                          style={{
+                            marginLeft: 8,
+                            color: getPriorityColor(item.priority),
+                            fontWeight: "bold",
+                          }}
+                        >
                           {item.priority.toUpperCase()}
                         </span>
                       )}
@@ -571,126 +667,153 @@ const GanttChart: React.FC = () => {
                 </div>
 
                 {/* Timeline Bar */}
-                <div style={{ 
-                  flex: 1,
-                  minWidth: '800px',
-                  position: 'relative',
-                  padding: '15px 0'
-                }}>
+                <div
+                  style={{
+                    flex: 1,
+                    minWidth: "800px",
+                    position: "relative",
+                    padding: "15px 0",
+                  }}
+                >
                   {/* Background Grid */}
-                  <div style={{
-                    position: 'absolute',
-                    top: 0,
-                    left: 0,
-                    right: 0,
-                    bottom: 0,
-                    display: 'flex'
-                  }}>
-                    {timelineView === 'week' ? (
-                      Array.from({ length: totalDays }, (_, i) => (
+                  <div
+                    style={{
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      right: 0,
+                      bottom: 0,
+                      display: "flex",
+                    }}
+                  >
+                    {timelineView === "week"
+                      ? Array.from({ length: totalDays }, (_, i) => (
                         <div
                           key={i}
                           style={{
                             width: `${(1 / totalDays) * 100}%`,
-                            borderRight: '1px solid #f0f0f0'
+                            borderRight: "1px solid #f0f0f0",
                           }}
                         />
                       ))
-                    ) : timelineView === 'quarter' ? (
-                      Array.from({ length: Math.ceil(totalDays / 30) }, (_, i) => (
-                        <div
-                          key={i}
-                          style={{
-                            width: `${(30 / totalDays) * 100}%`,
-                            borderRight: '1px solid #f0f0f0'
-                          }}
-                        />
-                      ))
-                    ) : (
-                      Array.from({ length: Math.ceil(totalDays / 7) }, (_, i) => (
-                        <div
-                          key={i}
-                          style={{
-                            width: `${(7 / totalDays) * 100}%`,
-                            borderRight: '1px solid #f0f0f0'
-                          }}
-                        />
-                      ))
-                    )}
+                      : timelineView === "quarter"
+                        ? Array.from(
+                          { length: Math.ceil(totalDays / 30) },
+                          (_, i) => (
+                            <div
+                              key={i}
+                              style={{
+                                width: `${(30 / totalDays) * 100}%`,
+                                borderRight: "1px solid #f0f0f0",
+                              }}
+                            />
+                          )
+                        )
+                        : Array.from(
+                          { length: Math.ceil(totalDays / 7) },
+                          (_, i) => (
+                            <div
+                              key={i}
+                              style={{
+                                width: `${(7 / totalDays) * 100}%`,
+                                borderRight: "1px solid #f0f0f0",
+                              }}
+                            />
+                          )
+                        )}
                   </div>
 
                   {/* Progress Bar */}
                   <div
                     style={{
-                      position: 'absolute',
-                      top: '50%',
-                      transform: 'translateY(-50%)',
-                      height: item.type === 'project' ? '24px' : '18px',
+                      position: "absolute",
+                      top: "50%",
+                      transform: "translateY(-50%)",
+                      height: item.type === "project" ? "24px" : "18px",
                       backgroundColor: getStatusColor(item.status, item.type),
-                      borderRadius: '4px',
-                      display: 'flex',
-                      alignItems: 'center',
-                      boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
-                      ...calculateBarStyle(item)
+                      borderRadius: "4px",
+                      display: "flex",
+                      alignItems: "center",
+                      boxShadow: "0 2px 4px rgba(0,0,0,0.1)",
+                      ...calculateBarStyle(item),
                     }}
                   >
                     {/* Progress Fill */}
                     <div
                       style={{
-                        height: '100%',
+                        height: "100%",
                         width: `${item.progress}%`,
-                        backgroundColor: item.status === 'completed' ? '#52c41a' : '#1890ff',
-                        borderRadius: '4px',
-                        opacity: 0.8
+                        backgroundColor:
+                          item.status === "completed" ? "#52c41a" : "#1890ff",
+                        borderRadius: "4px",
+                        opacity: 0.8,
                       }}
                     />
-                    
+
                     {/* Progress Text */}
-                    <div style={{
-                      position: 'absolute',
-                      left: '50%',
-                      transform: 'translateX(-50%)',
-                      fontSize: '10px',
-                      color: '#fff',
-                      fontWeight: 'bold',
-                      textShadow: '0 1px 2px rgba(0,0,0,0.5)'
-                    }}>
+                    <div
+                      style={{
+                        position: "absolute",
+                        left: "50%",
+                        transform: "translateX(-50%)",
+                        fontSize: "10px",
+                        color: "#fff",
+                        fontWeight: "bold",
+                        textShadow: "0 1px 2px rgba(0,0,0,0.5)",
+                      }}
+                    >
                       {item.progress}%
                     </div>
                   </div>
-                                  {item.type === 'task' && (() => {
-                                    const taskId = parseInt(item.id.replace('task-', ''));
-                                    const { dependencies } = getTaskDependencies(taskId);
-                                    const canStart = canStartTask(taskId);
-                                    return (
-                                      <>
-                                        {dependencies.length > 0 && (
-                                          <LinkOutlined style={{ marginRight: 4, color: '#1890ff', fontSize: '12px' }} />
-                                        )}
-                                        {!canStart && (
-                                          <ExclamationCircleOutlined style={{ marginRight: 4, color: '#faad14', fontSize: '12px' }} />
-                                        )}
-                                      </>
-                                    );
-                                  })()}
+                  {item.type === "task" &&
+                    (() => {
+                      const taskId = parseInt(item.id.replace("task-", ""));
+                      const { dependencies } = getTaskDependencies(taskId);
+                      const canStart = canStartTask(taskId);
+                      return (
+                        <>
+                          {dependencies.length > 0 && (
+                            <LinkOutlined
+                              style={{
+                                marginRight: 4,
+                                color: "#1890ff",
+                                fontSize: "12px",
+                              }}
+                            />
+                          )}
+                          {!canStart && (
+                            <ExclamationCircleOutlined
+                              style={{
+                                marginRight: 4,
+                                color: "#faad14",
+                                fontSize: "12px",
+                              }}
+                            />
+                          )}
+                        </>
+                      );
+                    })()}
 
                   {/* Today Line */}
                   {(() => {
                     const today = dayjs();
-                    if (today.isAfter(timelineStart) && today.isBefore(timelineEnd)) {
-                      const todayOffset = today.diff(timelineStart, 'days');
+                    if (
+                      today.isAfter(timelineStart) &&
+                      today.isBefore(timelineEnd)
+                    ) {
+                      const todayOffset = today.diff(timelineStart, "days");
                       const todayPosition = (todayOffset / totalDays) * 100;
-                      
+
                       return (
                         <div
                           style={{
-                            position: 'absolute',
+                            position: "absolute",
                             left: `${todayPosition}%`,
                             top: 0,
                             bottom: 0,
-                            width: '2px',
-                            backgroundColor: '#f5222d',
-                            zIndex: 5
+                            width: "2px",
+                            backgroundColor: "#f5222d",
+                            zIndex: 5,
                           }}
                         />
                       );
@@ -704,42 +827,71 @@ const GanttChart: React.FC = () => {
         </div>
 
         {/* Legend */}
-        <div style={{ 
-          marginTop: 16,
-          padding: '12px',
-          backgroundColor: '#f9f9f9',
-          borderRadius: '6px',
-          display: 'flex',
-          flexWrap: 'wrap',
-          gap: '16px',
-          fontSize: '12px'
-        }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-            <div style={{ width: '12px', height: '12px', backgroundColor: '#1890ff', borderRadius: '2px' }} />
+        <div
+          style={{
+            marginTop: 16,
+            padding: "12px",
+            backgroundColor: "#f9f9f9",
+            borderRadius: "6px",
+            display: "flex",
+            flexWrap: "wrap",
+            gap: "16px",
+            fontSize: "12px",
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+            <div
+              style={{
+                width: "12px",
+                height: "12px",
+                backgroundColor: "#1890ff",
+                borderRadius: "2px",
+              }}
+            />
             <span>In Progress</span>
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-            <div style={{ width: '12px', height: '12px', backgroundColor: '#52c41a', borderRadius: '2px' }} />
+          <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+            <div
+              style={{
+                width: "12px",
+                height: "12px",
+                backgroundColor: "#52c41a",
+                borderRadius: "2px",
+              }}
+            />
             <span>Completed</span>
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-            <div style={{ width: '12px', height: '12px', backgroundColor: '#faad14', borderRadius: '2px' }} />
+          <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+            <div
+              style={{
+                width: "12px",
+                height: "12px",
+                backgroundColor: "#faad14",
+                borderRadius: "2px",
+              }}
+            />
             <span>Planning/On Hold</span>
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-            <div style={{ width: '2px', height: '12px', backgroundColor: '#f5222d' }} />
+          <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+            <div
+              style={{
+                width: "2px",
+                height: "12px",
+                backgroundColor: "#f5222d",
+              }}
+            />
             <span>Today</span>
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-            <ProjectOutlined style={{ color: '#1890ff' }} />
+          <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+            <ProjectOutlined style={{ color: "#1890ff" }} />
             <span>Project</span>
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-            <LinkOutlined style={{ color: '#1890ff' }} />
+          <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+            <LinkOutlined style={{ color: "#1890ff" }} />
             <span>Has Dependencies</span>
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-            <ExclamationCircleOutlined style={{ color: '#faad14' }} />
+          <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+            <ExclamationCircleOutlined style={{ color: "#faad14" }} />
             <span>Waiting for Dependencies</span>
           </div>
         </div>

--- a/src/components/GanttChart.tsx
+++ b/src/components/GanttChart.tsx
@@ -154,7 +154,7 @@ const GanttChart: React.FC = () => {
 
       weeks.push({
         label: `Week ${current.week()} (${current.format('MMM DD')} - ${weekEnd.format('MMM DD')})`,
-        days: daysInWeek,
+        // days: daysInWeek,
         width: (daysInWeek / totalDays) * 100
       });
 

--- a/src/components/GanttChart.tsx
+++ b/src/components/GanttChart.tsx
@@ -461,33 +461,6 @@ const GanttChart: React.FC = () => {
                   ))}
                 </div>
               )}
-              {timelineView === 'week' && (
-                <div style={{
-                  display: 'flex',
-                  height: '30px',
-                  backgroundColor: '#f9f9f9'
-                }}>
-                  {Array.from({ length: totalDays }, (_, i) => {
-                    const date = timelineStart.add(i, 'day');
-                    return (
-                      <div
-                        key={i}
-                        style={{
-                          width: `${(1 / totalDays) * 100}%`,
-                          borderRight: '1px solid #e8e8e8',
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          fontSize: '9px',
-                          color: '#666'
-                        }}
-                      >
-                        {date.format('DD')}
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
               {timelineView === 'quarter' && (
                 <div style={{
                   display: 'flex',

--- a/src/components/GanttChart.tsx
+++ b/src/components/GanttChart.tsx
@@ -153,8 +153,8 @@ const GanttChart: React.FC = () => {
       );
 
       weeks.push({
-        label: `Week ${current.week()} (${current.format('MMM DD')} - ${weekEnd.format('MMM DD')})`,
-        // days: daysInWeek,
+        label: `W ${current.week()} (${current.format('MMM DD')} - ${weekEnd.format('MMM DD')})`,
+        days: daysInWeek,
         width: (daysInWeek / totalDays) * 100
       });
 


### PR DESCRIPTION
## Purpose

The user requested to extend the timeline functionality beyond the existing month view by adding week view and quarter view options to the filter. This enhancement provides users with more granular control over how they visualize project timelines in the Gantt chart.

## Code changes

- Added `timelineView` state to manage the current view type (week/month/quarter)
- Connected the timeline view selector dropdown to actually change the view state
- Implemented `generateWeekHeaders()` function to create weekly timeline headers
- Implemented `generateQuarterHeaders()` function to create quarterly timeline headers
- Refactored timeline header generation with a unified `generateTimelineHeaders()` function
- Added conditional sub-grid rendering based on the selected view type
- Updated grid lines to match the selected timeline view (daily for week view, monthly for quarter view)
- Adjusted font sizes and styling for different view types to improve readability

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c452f761df3148ebb3f1ee563beb0066/neon-home)

👀 [Preview Link](https://c452f761df3148ebb3f1ee563beb0066-neon-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c452f761df3148ebb3f1ee563beb0066</projectId>-->
<!--<branchName>neon-home</branchName>-->